### PR TITLE
Organize automation scripts into dedicated folder

### DIFF
--- a/scripts/automacao-gradepen copy.js
+++ b/scripts/automacao-gradepen copy.js
@@ -1,11 +1,11 @@
 // automacao-gradepen.js
 // Script principal que faz login, lê planilha e dispara inserção de questões
-// Depende de inserirQuestoes.js para o loop de inserção
+// Depende de insertQuestions.js para o loop de inserção
 
 const { chromium } = require('playwright');
 const XLSX = require('xlsx');
 const path = require('path');
-const { insertQuestions } = require('./inserirQuestoes');
+const { insertQuestions } = require('./automation/insertQuestions');
 
 (async () => {
   // === CONFIGURAÇÕES ===

--- a/scripts/automacao-gradepen.js
+++ b/scripts/automacao-gradepen.js
@@ -20,7 +20,7 @@ const QUESTION_CONFIG = {
   level: 1            // 1=Elementary, 2=High school, 3=Technical, 4=College/University
 };
 
-const { insertQuestions } = require('./inserirQuestoesTeste');
+const { insertQuestions } = require('./automation/insertQuestionsWithImages');
 
 (async () => {
   // 1) Ler a planilha (primeira aba)

--- a/scripts/automation/insertQuestions.js
+++ b/scripts/automation/insertQuestions.js
@@ -1,4 +1,4 @@
-// inserirQuestoes.js
+// insertQuestions.js
 const { URLSearchParams } = require('url');
 
 async function insertQuestions(apiRequest, rows) {

--- a/scripts/automation/insertQuestionsWithImages.js
+++ b/scripts/automation/insertQuestionsWithImages.js
@@ -1,4 +1,4 @@
-// scripts/inserirQuestoesTeste.js
+// insertQuestionsWithImages.js
 // Lê as colunas exatas da planilha e envia as questões por POST.
 // Mapeamentos (planilha → GradePen):
 // - Disciplina  -> courses[]       (Courses)
@@ -40,7 +40,7 @@ async function uploadImagesIfAny(api, imagesCell) {
   // separa por ; , | ou quebra de linha
   const parts = String(imagesCell).split(/[,;|\n]+/).map(s => s.trim()).filter(Boolean);
   for (const rel of parts) {
-    const abs = path.isAbsolute(rel) ? rel : path.resolve(__dirname, '..', 'data', rel);
+    const abs = path.isAbsolute(rel) ? rel : path.resolve(__dirname, '..', '..', 'data', rel);
     if (!fs.existsSync(abs)) {
       console.log(`   • ⚠️ imagem ignorada (arquivo não encontrado): ${rel}`);
       continue;


### PR DESCRIPTION
## Summary
- Move question insertion modules into scripts/automation
- Rename helpers to insertQuestions and insertQuestionsWithImages
- Update imports for new locations

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afac1f99548327b7f4501ad327b419