### PR TITLE
chore: configure entry script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "automacao-gradepen",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "scripts/automacao-gradepen.js",
   "scripts": {
+    "start": "node scripts/automacao-gradepen.js",
+    "dev": "node scripts/automacao-gradepen.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- point package main to scripts/automacao-gradepen.js
- add start and dev scripts for running automation

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start` (fails: executable doesn't exist at /root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome)


------
https://chatgpt.com/codex/tasks/task_e_68afac1958c08327a9348247b1d7f916