### PR TITLE
feat: add main entrypoint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "automacao-gradepen",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "scripts/main.js",
   "scripts": {
+    "start": "node scripts/main.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/scripts/automacao-gradepen.js
+++ b/scripts/automacao-gradepen.js
@@ -1,40 +1,19 @@
 // scripts/automacao-gradepen.js
-// Dependências: npm i playwright xlsx
-// Também: npx playwright install
+// Provides a helper to login and return a request context for the GradePen API.
 
-const path = require('path');
-const XLSX = require('xlsx');
 const { chromium, request } = require('playwright');
-
-// ========= CONFIG =========
-const EXCEL_PATH = path.resolve(__dirname, '../data/teste_grade_pen.xlsx');
 
 // Credenciais (pode mover para .env se quiser)
 const EMAIL = 'anderson.almeidap@outlook.com';
 const SENHA = 'Cad09025.';
 
-// Acesso/idioma/nível padrão para as questões
-const QUESTION_CONFIG = {
-  acesso: 2,          // 1=Public, 2=Private
-  idioma: 1,          // 0=Português, 1=English, 2=Español, 3=Arabic
-  level: 1            // 1=Elementary, 2=High school, 3=Technical, 4=College/University
-};
-
-const { insertQuestions } = require('./inserirQuestoesTeste');
-
-(async () => {
-  // 1) Ler a planilha (primeira aba)
-  const wb = XLSX.readFile(EXCEL_PATH);
-  const sheet = wb.Sheets[wb.SheetNames[0]];
-  const rows = XLSX.utils.sheet_to_json(sheet);
-
-  // 2) Abrir navegador e logar para obter cookies de sessão
+async function getApiContext() {
+  // 1) Abrir navegador e logar para obter cookies de sessão
   const browser = await chromium.launch({ headless: false });
   const page = await browser.newPage();
 
   console.log(`🔐 Fazendo login como ${EMAIL}...`);
   await page.goto('https://www.gradepen.com/p/index.php');
-
   await page.click('#btn-login');
   await page.fill('#inputEmail', EMAIL);
   await page.fill('#inputPwd', SENHA);
@@ -44,16 +23,15 @@ const { insertQuestions } = require('./inserirQuestoesTeste');
   await page.waitForTimeout(3000);
   console.log('✅ Login bem-sucedido!');
 
-  // 3) Criar um API client com mesmos cookies (para os POSTs diretos)
+  // 2) Criar um API client com os cookies de sessão
   const cookies = await page.context().cookies();
-  const apiRequest = await request.newContext({
+  const api = await request.newContext({
     baseURL: 'https://www.gradepen.com',
     extraHTTPHeaders: {
       'Accept': '*/*',
       'Referer': 'https://www.gradepen.com/p/avaliacoes.php',
       'Origin': 'https://www.gradepen.com'
     },
-    // injeta cookies de sessão
     cookies: cookies.map(c => ({
       name: c.name,
       value: c.value,
@@ -65,10 +43,7 @@ const { insertQuestions } = require('./inserirQuestoesTeste');
     }))
   });
 
-  // 4) Inserir as questões a partir da planilha
-  await insertQuestions({ api: apiRequest, page }, rows, QUESTION_CONFIG);
+  return { api, browser, page };
+}
 
-  // 5) Fechar
-  await apiRequest.dispose();
-  await browser.close();
-})();
+module.exports = { getApiContext };

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,40 @@
+// scripts/main.js
+// Entry point that reads the Excel file, obtains an API context and inserts questions.
+
+const path = require('path');
+const XLSX = require('xlsx');
+
+const { getApiContext } = require('./automacao-gradepen');
+const { insertQuestions } = require('./inserirQuestoes');
+
+// Caminho da planilha e configuração padrão
+const EXCEL_PATH = path.resolve(__dirname, '../data/teste_grade_pen.xlsx');
+const QUESTION_CONFIG = {
+  acesso: 2,  // 1=Public, 2=Private
+  idioma: 1,  // 0=Português, 1=English, 2=Español, 3=Arabic
+  level: 1    // 1=Elementary, 2=High school, 3=Technical, 4=College/University
+};
+
+async function main() {
+  // 1) Ler planilha
+  const workbook = XLSX.readFile(EXCEL_PATH);
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet);
+
+  // 2) Obter contexto de API (login + cookies)
+  const { api, browser } = await getApiContext();
+
+  try {
+    // 3) Inserir questões
+    await insertQuestions(api, rows, QUESTION_CONFIG);
+  } finally {
+    // 4) Limpeza de recursos
+    await api.dispose();
+    await browser.close();
+  }
+}
+
+main().catch(err => {
+  console.error('Erro na execução:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- export `getApiContext` helper to log in and obtain a GradePen API client
- add `scripts/main.js` to read spreadsheet, insert questions and clean up resources
- wire `npm start` to run the new script

## Testing
- `npm test >/tmp/unit.log 2>&1; tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68afb47d18d483279d1b071cacd0cbea