### PR TITLE
Refactor login setup

### DIFF
--- a/scripts/automacao-gradepen.js
+++ b/scripts/automacao-gradepen.js
@@ -9,26 +9,16 @@ const { chromium, request } = require('playwright');
 // ========= CONFIG =========
 const EXCEL_PATH = path.resolve(__dirname, '../data/teste_grade_pen.xlsx');
 
-// Credenciais (pode mover para .env se quiser)
-const EMAIL = 'anderson.almeidap@outlook.com';
-const SENHA = 'Cad09025.';
+const { insertQuestions } = require('./inserirQuestoes');
 
-// Acesso/idioma/nível padrão para as questões
-const QUESTION_CONFIG = {
-  acesso: 2,          // 1=Public, 2=Private
-  idioma: 1,          // 0=Português, 1=English, 2=Español, 3=Arabic
-  level: 1            // 1=Elementary, 2=High school, 3=Technical, 4=College/University
-};
+async function createApiContext() {
+  const EMAIL = process.env.GRADEPEN_EMAIL;
+  const SENHA = process.env.GRADEPEN_PASSWORD;
 
-const { insertQuestions } = require('./inserirQuestoesTeste');
+  if (!EMAIL || !SENHA) {
+    throw new Error('GRADEPEN_EMAIL e GRADEPEN_PASSWORD devem estar definidos');
+  }
 
-(async () => {
-  // 1) Ler a planilha (primeira aba)
-  const wb = XLSX.readFile(EXCEL_PATH);
-  const sheet = wb.Sheets[wb.SheetNames[0]];
-  const rows = XLSX.utils.sheet_to_json(sheet);
-
-  // 2) Abrir navegador e logar para obter cookies de sessão
   const browser = await chromium.launch({ headless: false });
   const page = await browser.newPage();
 
@@ -44,16 +34,14 @@ const { insertQuestions } = require('./inserirQuestoesTeste');
   await page.waitForTimeout(3000);
   console.log('✅ Login bem-sucedido!');
 
-  // 3) Criar um API client com mesmos cookies (para os POSTs diretos)
   const cookies = await page.context().cookies();
-  const apiRequest = await request.newContext({
+  const api = await request.newContext({
     baseURL: 'https://www.gradepen.com',
     extraHTTPHeaders: {
       'Accept': '*/*',
       'Referer': 'https://www.gradepen.com/p/avaliacoes.php',
       'Origin': 'https://www.gradepen.com'
     },
-    // injeta cookies de sessão
     cookies: cookies.map(c => ({
       name: c.name,
       value: c.value,
@@ -65,10 +53,31 @@ const { insertQuestions } = require('./inserirQuestoesTeste');
     }))
   });
 
-  // 4) Inserir as questões a partir da planilha
-  await insertQuestions({ api: apiRequest, page }, rows, QUESTION_CONFIG);
+  return { api, page, browser };
+}
 
-  // 5) Fechar
-  await apiRequest.dispose();
+async function run() {
+  // 1) Ler a planilha (primeira aba)
+  const wb = XLSX.readFile(EXCEL_PATH);
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet);
+
+  // 2) Obter contexto de API/logado
+  const { api, browser } = await createApiContext();
+
+  // 3) Inserir as questões a partir da planilha
+  await insertQuestions(api, rows);
+
+  // 4) Fechar
+  await api.dispose();
   await browser.close();
-})();
+}
+
+if (require.main === module) {
+  run().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { createApiContext, run };


### PR DESCRIPTION
## Summary
- extract GradePen login into exported `createApiContext`
- pull credentials from environment variables
- switch to using `inserirQuestoes.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afb47af7d08327814955df511315ce