### PR TITLE
Handle invalid JSON responses when inserting questions

### DIFF
--- a/scripts/inserirQuestoes.js
+++ b/scripts/inserirQuestoes.js
@@ -151,7 +151,18 @@ async function enviarQuestao(api, row, config) {
 
   try {
     const resp = await api.post('/p/requests/createUpdateQuestion.php', { form });
-    const data = await resp.json();
+    if (resp.status && resp.status() !== 200) {
+      console.log(`   • ⚠️ HTTP status ${resp.status()}`);
+    }
+
+    const body = await resp.text();
+    let data;
+    try {
+      data = JSON.parse(body);
+    } catch (e) {
+      console.log(`   • ❌ resposta não JSON: ${body}`);
+      return { ok: false, code: 'PARSE', msg: 'Resposta inválida do servidor' };
+    }
 
     if (data?.success) {
       const eid = data?.question?.eid || '?';


### PR DESCRIPTION
## Summary
- Avoid crashing when question insertion endpoint returns invalid JSON
- Log HTTP status code for non-200 responses

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afc976ca888327bf6c556694f05e04