### PR TITLE
Log status and body for non-200 responses

### DIFF
--- a/scripts/inserirQuestoes.js
+++ b/scripts/inserirQuestoes.js
@@ -151,11 +151,13 @@ async function enviarQuestao(api, row, config) {
 
   try {
     const resp = await api.post('/p/requests/createUpdateQuestion.php', { form });
-    if (resp.status && resp.status() !== 200) {
-      console.log(`   • ⚠️ HTTP status ${resp.status()}`);
+    const statusCode = resp.status ? resp.status() : undefined;
+    const body = await resp.text();
+    if (statusCode !== undefined && statusCode !== 200) {
+      console.log(`   • ⚠️ HTTP status ${statusCode}`);
+      console.log(`   • ⚠️ corpo completo:\n${body}`);
     }
 
-    const body = await resp.text();
     let data;
     try {
       data = JSON.parse(body);


### PR DESCRIPTION
## Summary
- log HTTP status and full response body when create question returns non-200

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afcac657b88327b3bdec2b9e0195fc