### PR TITLE
Ensure empty courses and subjects fields

### DIFF
--- a/scripts/inserirQuestoes.js
+++ b/scripts/inserirQuestoes.js
@@ -148,9 +148,9 @@ async function enviarQuestao(api, row, config) {
     sugestaoLinhasDesenho: 0,
     // tags (autocomplete)
     courses: '',
-    'courses[]': disciplina ? [disciplina] : [],
+    'courses[]': disciplina ? [disciplina] : '',
     subjects: '',
-    'subjects[]': tema ? [tema] : []
+    'subjects[]': tema ? [tema] : ''
   };
 
   try {


### PR DESCRIPTION
## Summary
- Ensure `courses[]` and `subjects[]` are always present in payload, defaulting to empty strings when discipline or theme is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afd0cdb7bc8327ae64a7cf914f8631