### PR TITLE
Corrigir envio de respostas no formulário de questões

### DIFF
--- a/scripts/inserirQuestoes.js
+++ b/scripts/inserirQuestoes.js
@@ -113,10 +113,12 @@ async function enviarQuestao(api, row, config) {
   const altD = sanitizeStr(row['Alternativa D'] ?? row['Alernativa D']);
   const altE = sanitizeStr(row['Alternativa E'] ?? row['Alernativa E']);
   const gabarito = sanitizeStr(row['Gabarito']).trim().toUpperCase();
-
+  
   const correctIndex = ['A', 'B', 'C', 'D', 'E'].indexOf(gabarito);
-  const respostas = correctIndex >= 0 ? [correctIndex] : [];
-  if (correctIndex === -1) {
+  const respostas = Array(5).fill('0');
+  if (correctIndex >= 0) {
+    respostas[correctIndex] = '1';
+  } else {
     console.log(`   • ⚠️ gabarito inválido: "${gabarito}"`);
   }
 
@@ -126,32 +128,31 @@ async function enviarQuestao(api, row, config) {
   const banca      = sanitizeStr(row['Banca']);      // autor
   const ano        = sanitizeStr(row['Ano']);        // ano
 
-  const form = {
-    id: 0,
-    idPai: 0,
-    tipo: 2, // Multiple-Choice
-    acesso: config.acesso,
-    autor: banca,
-    ano: ano,
-    idioma: config.idioma,
-    level: config.level,
-    problema: problemaHTML,
-    // alternativas
-    'alternativas[0]': altA,
-    'alternativas[1]': altB,
-    'alternativas[2]': altC,
-    'alternativas[3]': altD,
-    'alternativas[4]': altE,
-    'respostas[]': respostas,
-    // linhas sugeridas (para discursiva) — manter 0
-    sugestaoLinhasTexto: 0,
-    sugestaoLinhasDesenho: 0,
-    // tags (autocomplete)
-    courses: '',
-    'courses[]': disciplina ? [disciplina] : [],
-    subjects: '',
-    'subjects[]': tema ? [tema] : []
-  };
+  const form = new URLSearchParams();
+  form.append('id', '0');
+  form.append('idPai', '0');
+  form.append('tipo', '2'); // Multiple-Choice
+  form.append('acesso', String(config.acesso));
+  form.append('autor', banca);
+  form.append('ano', ano);
+  form.append('idioma', String(config.idioma));
+  form.append('level', String(config.level));
+  form.append('problema', problemaHTML);
+  // alternativas
+  form.append('alternativas[0]', altA);
+  form.append('alternativas[1]', altB);
+  form.append('alternativas[2]', altC);
+  form.append('alternativas[3]', altD);
+  form.append('alternativas[4]', altE);
+  respostas.forEach(r => form.append('respostas[]', r));
+  // linhas sugeridas (para discursiva) — manter 0
+  form.append('sugestaoLinhasTexto', '0');
+  form.append('sugestaoLinhasDesenho', '0');
+  // tags (autocomplete)
+  form.append('courses', '');
+  if (disciplina) form.append('courses[]', disciplina);
+  form.append('subjects', '');
+  if (tema) form.append('subjects[]', tema);
 
   try {
     const resp = await api.post('/p/requests/createUpdateQuestion.php', { form });


### PR DESCRIPTION
## Summary
- Gera array de cinco posições com `1` na alternativa correta e `0` nas demais
- Envia cada item de `respostas[]` individualmente usando `URLSearchParams`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afd0caee048327b892b52f42ceaaa7